### PR TITLE
Use protocol agnostic for web base

### DIFF
--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -43,7 +43,7 @@ module.exports = function(config, auth, storage) {
   app.get('/', function(req, res, next) {
     var base = config.url_prefix
              ? config.url_prefix.replace(/\/$/, '')
-             : req.protocol + '://' + req.get('host')
+             : '//' + req.get('host')
     res.setHeader('Content-Type', 'text/html')
 
     storage.get_local(function(err, packages) {


### PR DESCRIPTION
http://www.paulirish.com/2010/the-protocol-relative-url/  - we run sinopia behind nginx (which does the SSL termination), we're forwarding the host header however the protocol was referring to the non-SSL connection between sinopia/nginx. The idea here is to resolve protocol in the browser based on the document protocol